### PR TITLE
fix IndexName typo in Query struct

### DIFF
--- a/endpoints/query/query.go
+++ b/endpoints/query/query.go
@@ -46,7 +46,7 @@ type Query struct {
 	ExpressionAttributeNames  expressionattributenames.ExpressionAttributeNames `json:",omitempty"`
 	ExpressionAttributeValues attributevalue.AttributeValueMap                  `json:",omitempty"`
 	FilterExpression          string                                            `json:",omitempty"`
-	Indexname                 string                                            `json:",omitempty"`
+	IndexName                 string                                            `json:",omitempty"`
 	KeyConditions             condition.Conditions
 	Limit                     uint64               `json:",omitempty"`
 	ProjectionExpression      string               `json:",omitempty"`


### PR DESCRIPTION
There is a typo in the `Query` struct, `Indexname` should be changed to `IndexName`: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-IndexName